### PR TITLE
docs: update USE_CASES.md to reference actual consolidated skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ This repository is a collection of specialized **Agent Skills** and **Subagents*
 
 Learn how to leverage this repository for common GitHub workflows:
 
-- **[Automated Issue Triage](docs/USE_CASES.md#1-automated-issue-triage)**: Categorize and assign incoming issues automatically.
-- **[Project Board Sync](docs/USE_CASES.md#2-project-board-synchronization)**: Keep your Project v2 boards in sync with repository state.
-- **[Sprint Planning](docs/USE_CASES.md#3-sprintrelease-planning)**: Organize work into milestones and target versions.
-- **[Repo Reorganization](docs/USE_CASES.md#4-repository-reorganization)**: Smoothly transfer issues between repositories.
+- **[Initial Project Config Setup](docs/USE_CASES.md#0-initial-project-config-setup-one-time-per-repository)**: One-time setup to declare the active project and enable silent auto-verification.
+- **[Automated Issue Triage](docs/USE_CASES.md#1-automated-issue-triage)**: Categorize and assign incoming issues automatically using `gh-issue-management`.
+- **[Project Board Sync](docs/USE_CASES.md#2-project-board-synchronization)**: Keep your Project v2 boards in sync with repository state using `gh-project-management`.
+- **[Sprint Planning](docs/USE_CASES.md#3-sprintrelease-planning)**: Organize work into milestones and target versions using `gh-issue-management` and `gh-project-management`.
+- **[Repo Reorganization](docs/USE_CASES.md#4-repository-reorganization)**: Smoothly transfer issues between repositories using `gh-issue-management`.
 
 ## Standards
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -66,12 +66,14 @@ To switch to a different project, re-run `gh-set-active-project` to overwrite th
 
 ### Planning Workflow
 
-1. **Discovery**: Use `gh-searching-issues` to find high-priority bugs and requested features.
-2. **Milestone Assignment**: Use `gh-setting-milestones` to group identified issues into a specific release version.
-3. **Project Organization**:
-   - Use `gh-listing-project-fields` to find custom fields like "Sprint" or "Target Version".
-   - Use `gh-updating-project-fields` to batch-update the project board with the new planning data.
-4. **Tracking**: Use `gh-listing-milestones` to monitor progress toward the release goal.
+0. **Prerequisite**: Run `gh-set-active-project` once to create `.github/project-config.json`.
+1. **Context**: `gh-verifying-context` auto-verifies against the config silently.
+2. **Discovery**: Use `gh-issue-management` to search for high-priority bugs and requested features.
+3. **Milestone Assignment**: Use `gh-issue-management` to group identified issues into a specific release version via `gh issue edit --milestone`.
+4. **Project Organization**:
+   - Use `gh-project-management` to list custom fields (e.g., "Sprint" or "Target Version") with `gh project field-list`.
+   - Use `gh-project-management` to batch-update the project board with the new planning data via `gh project item-edit`.
+5. **Tracking**: Use `gh-issue-management` to list issues filtered by milestone to monitor progress toward the release goal.
 
 ---
 
@@ -81,7 +83,9 @@ To switch to a different project, re-run `gh-set-active-project` to overwrite th
 
 ### Reorg Workflow
 
-1. **Audit**: Use `gh-searching-issues` to find issues in a repository that actually belong in a different part of the organization.
-2. **Transfer**: Use `gh-transferring-issues` to move the issue to the correct destination repository.
-3. **Linkage**: Use `gh-commenting-on-issues` on both the old and new issue to provide traceability.
-4. **Cleanup**: Use `gh-labeling-issues` on the new repository to ensure the transferred work matches the destination's triage standards.
+0. **Prerequisite**: Run `gh-set-active-project` once to create `.github/project-config.json`.
+1. **Context**: `gh-verifying-context` auto-verifies against the config silently.
+2. **Audit**: Use `gh-issue-management` to search for issues that belong in a different part of the organization.
+3. **Transfer**: Use `gh-issue-management` to move the issue to the correct destination repository via `gh issue transfer`.
+4. **Linkage**: Use `gh-issue-management` to comment on both the old and new issue to provide traceability via `gh issue comment`.
+5. **Cleanup**: Use `gh-issue-management` on the new repository to apply labels matching the destination's triage standards via `gh issue edit --add-label`.


### PR DESCRIPTION
Replace references to non-existent atomic skills (gh-searching-issues,
gh-setting-milestones, gh-listing-project-fields, gh-updating-project-fields,
gh-listing-milestones, gh-transferring-issues, gh-commenting-on-issues,
gh-labeling-issues) with the actual consolidated skills (gh-issue-management
and gh-project-management) that implement these operations.

https://claude.ai/code/session_01Q656tjxygVnXbSw4jhPRBe