### PR TITLE
fix(plugin): point skills entries at directories, not SKILL.md files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,10 +13,10 @@
     "./agents/github-project-manager/SKILL.md"
   ],
   "skills": [
-    "./skills/gh-set-active-project/SKILL.md",
-    "./skills/gh-verifying-context/SKILL.md",
-    "./skills/gh-issue-management/SKILL.md",
-    "./skills/gh-project-management/SKILL.md",
-    "./skills/gh-linking-branches-to-issues/SKILL.md"
+    "./skills/gh-set-active-project",
+    "./skills/gh-verifying-context",
+    "./skills/gh-issue-management",
+    "./skills/gh-project-management",
+    "./skills/gh-linking-branches-to-issues"
   ]
 }


### PR DESCRIPTION
All five skills in this plugin currently fail to load in Claude Code, so the plugin is reported as `failed to load`.

## Cause

`.claude-plugin/plugin.json` lists each `skills` entry as a path to the `SKILL.md` file. Claude Code expects the entry to be the **directory** that contains `SKILL.md`.

`claude plugin list` reports (once per skill):

```
Status: ✘ failed to load
Error: skills load failed from ./skills/gh-set-active-project/SKILL.md: path is a file;
skills entries must be directories containing SKILL.md — point to the parent directory
'./skills/gh-set-active-project' instead
```

## Fix

Drop the trailing `/SKILL.md` from the five `skills` entries. The `agents` entries use a different loader and are unaffected, so they are left unchanged.

## Verification

With this change, `claude plugin list` reports the plugin as `✔ enabled` and `claude plugin details` lists all five skills.